### PR TITLE
Add null provider to make plugin privacy compliant.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace atto_chemistry\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy Subsystem for atto_chemistry implementing null_provider.
+ *
+ * @copyright  2018 Mathieu Petit-Clair <mathieu@petitclair.ca>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() : string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/atto_chemistry.php
+++ b/lang/en/atto_chemistry.php
@@ -50,6 +50,7 @@ $string['librarygroup7_title'] = 'Lanthanoid and actinoid elements';
 $string['librarygroup7_desc'] = 'TeX commands listed on the elements: La-Lu and Ac-Lr tab.';
 $string['pluginname'] = 'Chemistry editor';
 $string['preview'] = 'Chemistry preview';
+$string['privacy:metadata'] = 'The atto_chemistry plugin does not store any personal data.';
 $string['cursorinfo'] = 'An arrow indicates the position that new elements from the element library will be inserted.';
 $string['savechemistry'] = 'Save chemistry';
 $string['settings'] = 'Chemistry editor settings';


### PR DESCRIPTION
Hi Geoff,

Here's a trivial GDPR/Privacy API patch for this plugin to make it fully 3.5 compliant. Hopefully you see no problem into pulling this into the master branch.

Thanks,

Mat